### PR TITLE
@file references removed from Doxygen comments

### DIFF
--- a/src/main/java/WrightFlightManager/GUI/FlightAttendantAccountCreationToGUI.java
+++ b/src/main/java/WrightFlightManager/GUI/FlightAttendantAccountCreationToGUI.java
@@ -8,9 +8,9 @@ import java.awt.event.ActionListener;
 import java.io.FileWriter;
 import java.io.IOException;
 /**
- * @file FlightAttendantAccountCreationToGUI.java
- *
  * @brief This class represents a graphical user interface (GUI) for creating Flight Attendant accounts in a system.
+ * <p>
+ * This class represents a graphical user interface (GUI) for creating Flight Attendant accounts in a system.
  * The class extends JFrame to create a main window for the account creation interface. It contains labels,
  * text fields, a combo box, and a button to capture user inputs for creating a new account. The account
  * information (username, password, and account type) is saved to a file after successful creation.
@@ -26,6 +26,7 @@ public class FlightAttendantAccountCreationToGUI extends JFrame {
     private JButton createButton;
     /**
      * @brief Constructor for the FlightAttendantAccountCreationToGUI class.
+     * <p>
      * Initializes the main frame and creates all the GUI components required for the account creation.
      * It sets the layout, size, and properties of the frame. Action listeners are registered for the
      * "Create Account" button to trigger the account creation process.

--- a/src/main/java/WrightFlightManager/GUI/FlightAttendantView.java
+++ b/src/main/java/WrightFlightManager/GUI/FlightAttendantView.java
@@ -7,12 +7,6 @@ import java.awt.event.ActionListener;
 
 //change functionality according to available database
 //Issue no 49
-/**
- * @file FlightAttendantView.java
- *
- * @brief Contains the definition of the FlightAttendantView class, which extends JFrame.
- *
- */
 
 /**
  * @class FlightAttendantView


### PR DESCRIPTION
As previously discussed these @file references are unnecessary. There is no advantage to being able to go through the file organization vs the class organization. Every class is in its own file.